### PR TITLE
Determine minimum supported PHP and dependencies versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ jobs:
     name: CI PHPStan
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version: [ '7.0', '7.1', '7.2' ]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -14,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring, sockets
 
       - name: Get composer cache directory
@@ -38,6 +42,11 @@ jobs:
   code-sniffer:
     name: CI Code sniffer
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: [ '7.0', '7.1', '7.2' ]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring, sockets
 
       - name: Get composer cache directory
@@ -72,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '7.2', '7.4' ]
+        php-version: [ '7.0', '7.1', '7.2', '7.4' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ jobs:
     name: CI PHPStan
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        php-version: [ '7.0', '7.1', '7.2' ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: '7.2'
           extensions: mbstring, sockets
 
       - name: Get composer cache directory
@@ -43,10 +39,6 @@ jobs:
     name: CI Code sniffer
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        php-version: [ '7.0', '7.1', '7.2' ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: '7.2'
           extensions: mbstring, sockets
 
       - name: Get composer cache directory
@@ -81,7 +73,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '7.0', '7.1', '7.2', '7.4' ]
+        php-version: [ '7.2', '7.4' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,6 @@ jobs:
   phpstan:
     name: CI PHPStan
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --prefer-dist --optimize-autoloader
+
       - name: Run phpstan
         run: composer phpstan
 
@@ -63,7 +64,8 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --prefer-dist --optimize-autoloader
-      - name: Run phpstan
+
+      - name: Run phpcs
         run: composer phpcs
 
   phpunit:
@@ -81,7 +83,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring, sockets
 
       - name: Get composer cache directory
@@ -98,5 +100,6 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --prefer-dist --optimize-autoloader
+
       - name: Run phpunit
         run: composer phpunit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
     strategy:
       matrix:
         php-version: [ '7.2', '7.4' ]
+        composer-cmd: [ 'install', 'update --prefer-lowest' ]
 
     steps:
       - name: Checkout
@@ -98,7 +99,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --no-progress --prefer-dist --optimize-autoloader
+          composer ${{ matrix.composer-cmd }} --no-progress --prefer-dist --optimize-autoloader
 
       - name: Run phpunit
         run: composer phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         "php": ">=7.2.0",
         "psr/log": "^1.1",
         "doctrine/collections": "^1.5",
-        "php-amqplib/php-amqplib": "^2.9",
+        "php-amqplib/php-amqplib": "^2.12.2",
         "brandembassy/datetime": "^3.0",
         "nette/utils": "^3.0"
     },
     "require-dev": {
         "brandembassy/coding-standard": "^8.1",
-        "brandembassy/mockery-tools": "^2.0",
+        "brandembassy/mockery-tools": "^2.8",
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^8.5",
         "roave/security-advisories": "dev-latest"

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     },
     "require": {
+        "php": ">=7.2.0",
         "psr/log": "^1.1",
         "doctrine/collections": "^1.5",
         "php-amqplib/php-amqplib": "^2.9",


### PR DESCRIPTION
Pod PHP 7.2 to nejede a v `php-amqplib/php-amqplib v2.12.2` přibyla použitá metoda `Message::setChannel()`, kterou používáme (viz https://github.com/php-amqplib/php-amqplib/commit/6f53b0e2d4ad04308011c2d5b38d770444db83d7)

Upravil jsem CI tak, aby se nám to do budoucna nerozbilo :slightly_smiling_face: 