### PR TITLE
RabbitMQQueueManager: remove duplicate adding to Collection

### DIFF
--- a/src/Queue/RabbitMQ/RabbitMQQueueManager.php
+++ b/src/Queue/RabbitMQ/RabbitMQQueueManager.php
@@ -147,7 +147,6 @@ class RabbitMQQueueManager implements QueueManagerInterface
         }
 
         $this->declareQueue($queueName, $arguments);
-        $this->declaredQueues->add($queueName);
     }
 
 


### PR DESCRIPTION
The `string $queueName` gets added to the Collection twice: once in the `declareQueue` call and once in the `declareQueueIfNotDeclared` itself.