### PR TITLE
Run CI for PHP 8.0 and 8.1 as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ jobs:
     name: CI PHPStan
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version: [ '7.4', '8.0', '8.1' ]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -14,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring, sockets
 
       - name: Get composer cache directory
@@ -73,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '7.4' ]
+        php-version: [ '7.4', '8.0', '8.1' ]
         composer-cmd: [ 'install', 'update --prefer-lowest' ]
 
     steps:


### PR DESCRIPTION
Our `composer.json` declares PHP requirement as >=7.4, trying to run CI on PHP 8.0 and 8.1 to see if there are any incompatibilities.