### PR TITLE
Update composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/composer.lock
 /vendor/
 /var/

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     },
     "require": {
         "php": ">=7.4.0",
+        "ext-json": "*",
         "psr/log": "^1.1",
         "doctrine/collections": "^1.5",
         "php-amqplib/php-amqplib": "^2.12.2",

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "lock": false
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2"
     },
     "scripts": {
-        "phpcs": "./vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src tests",
-        "phpcbf": "./vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src tests",
+        "phpcs": "./vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src tests --runtime-set php_version 70400",
+        "phpcbf": "./vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src tests --runtime-set php_version 70400",
         "phpstan": "./vendor/bin/phpstan analyze -c phpstan.neon src tests --memory-limit=-1",
         "phpunit": "./vendor/bin/phpunit tests --no-coverage",
         "phpunit-cc": "./vendor/bin/phpunit tests"


### PR DESCRIPTION
Minor improvements of `composer.json`, inspired by coding-standard package. JSON extension was missing, even though we use `json_decode` in `SqsQueueManager`.