### PR TITLE
SqsQueueManager: Add possibility to prefix queue names

### DIFF
--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -303,7 +303,7 @@ class SqsQueueManager implements QueueManagerInterface
 
         if (!Validators::isUrl($prefixedQueueName)) {
             throw new LogicException(
-                'In SQS, queue name is supposed to be a URL. '
+                'In SQS, queue name is supposed to be a URL, "' . $prefixedQueueName . '" provided instead. '
                 . 'A prefix can be used to prepend a common part of the URL to uniquely named queues.',
             );
         }

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -304,7 +304,7 @@ class SqsQueueManager implements QueueManagerInterface
         if (!Validators::isUrl($prefixedQueueName)) {
             throw new LogicException(
                 'In SQS, queue name is supposed to be a URL. '
-                . 'A prefix can be used to prepend a common part of the URL to uniquely named queues.'
+                . 'A prefix can be used to prepend a common part of the URL to uniquely named queues.',
             );
         }
 

--- a/tests/Jobs/JobDefinitions/ExampleJobDefinition.php
+++ b/tests/Jobs/JobDefinitions/ExampleJobDefinition.php
@@ -23,6 +23,8 @@ class ExampleJobDefinition implements JobDefinitionInterface
 
     private string $jobClass;
 
+    private string $queueName = self::QUEUE_NAME;
+
     private ?DelayRuleInterface $delayRule = null;
 
     private ?JobProcessorInterface $jobProcessor = null;
@@ -38,6 +40,15 @@ class ExampleJobDefinition implements JobDefinitionInterface
     public static function create(string $jobName = ExampleJob::JOB_NAME, string $jobClass = ExampleJob::class): self
     {
         return new self($jobName, $jobClass);
+    }
+
+
+    public function withQueueName(string $queueName): self
+    {
+        $clone = clone $this;
+        $clone->queueName = $queueName;
+
+        return $clone;
     }
 
 
@@ -82,7 +93,7 @@ class ExampleJobDefinition implements JobDefinitionInterface
 
     public function getQueueName(): string
     {
-        return self::QUEUE_NAME;
+        return $this->queueName;
     }
 
 

--- a/tests/Queue/AWSSQS/SqsQueueManagerTest.php
+++ b/tests/Queue/AWSSQS/SqsQueueManagerTest.php
@@ -340,7 +340,7 @@ class SqsQueueManagerTest extends TestCase
 
     private function createExampleJob(): ExampleJob
     {
-        return new ExampleJob();
+        return new ExampleJob(ExampleJobDefinition::create('https://my-aws-sqs:9324/account-id/' . ExampleJob::JOB_NAME));
     }
 
 

--- a/tests/Queue/AWSSQS/SqsQueueManagerTest.php
+++ b/tests/Queue/AWSSQS/SqsQueueManagerTest.php
@@ -109,7 +109,10 @@ class SqsQueueManagerTest extends TestCase
 
         $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
 
-        $exampleJob = ExampleJob::createTooBigForSqs();
+        $exampleJob = ExampleJob::createTooBigForSqs(
+            ExampleJobDefinition::create()
+                ->withQueueName(self::QUEUE_URL),
+        );
 
         $this->s3ClientMock->expects('upload')
             ->with(
@@ -342,7 +345,7 @@ class SqsQueueManagerTest extends TestCase
     {
         return new ExampleJob(
             ExampleJobDefinition::create()
-                ->withQueueName(self::QUEUE_URL)
+                ->withQueueName(self::QUEUE_URL),
         );
     }
 

--- a/tests/Queue/AWSSQS/SqsQueueManagerTest.php
+++ b/tests/Queue/AWSSQS/SqsQueueManagerTest.php
@@ -340,7 +340,10 @@ class SqsQueueManagerTest extends TestCase
 
     private function createExampleJob(): ExampleJob
     {
-        return new ExampleJob(ExampleJobDefinition::create('https://my-aws-sqs:9324/account-id/' . ExampleJob::JOB_NAME));
+        return new ExampleJob(
+            ExampleJobDefinition::create()
+                ->withQueueName('https://my-aws-sqs:9324/account-id/' . ExampleJobDefinition::QUEUE_NAME)
+        );
     }
 
 

--- a/tests/Queue/AWSSQS/SqsQueueManagerTest.php
+++ b/tests/Queue/AWSSQS/SqsQueueManagerTest.php
@@ -333,8 +333,8 @@ class SqsQueueManagerTest extends TestCase
     {
         return $message['MessageBody'] === $messageBody
             && $message[SqsSendingMessageFields::DELAY_SECONDS] === $delay
-            && $message[SqsSendingMessageFields::QUEUE_URL] === ExampleJobDefinition::QUEUE_NAME
-            && $message[SqsSendingMessageFields::MESSAGE_ATTRIBUTES][SqsSendingMessageFields::QUEUE_URL]['StringValue'] === ExampleJobDefinition::QUEUE_NAME;
+            && $message[SqsSendingMessageFields::QUEUE_URL] === self::QUEUE_URL
+            && $message[SqsSendingMessageFields::MESSAGE_ATTRIBUTES][SqsSendingMessageFields::QUEUE_URL]['StringValue'] === self::QUEUE_URL;
     }
 
 
@@ -342,7 +342,7 @@ class SqsQueueManagerTest extends TestCase
     {
         return new ExampleJob(
             ExampleJobDefinition::create()
-                ->withQueueName('https://my-aws-sqs:9324/account-id/' . ExampleJobDefinition::QUEUE_NAME)
+                ->withQueueName(self::QUEUE_URL)
         );
     }
 


### PR DESCRIPTION
You can use an URL as a queue name directly but that would require defining a new job. Prefixing queue names for SQS allows prepending a common part of the URL to uniquely named queues, without the need to define new jobs. That should lead to more consistent code.