### PR TITLE
Job execution planned at - prototype

### DIFF
--- a/src/Jobs/Execution/JobLoader.php
+++ b/src/Jobs/Execution/JobLoader.php
@@ -38,13 +38,15 @@ class JobLoader implements JobLoaderInterface
 
         $jobLoader = $jobDefinition->getJobLoader();
 
-        return $jobLoader->load(
+        $job = $jobLoader->load(
             $jobDefinition,
             $jobUuid,
             DateTimeFromString::create($messageParameters[JobParameters::CREATED_AT]),
             $attempts,
             new ArrayCollection($messageParameters[JobParameters::PARAMETERS]),
         );
+
+        $job->planExecution($messageParameters[JobParameters::EXECUTION_PLANNED_AT]);
     }
 
 

--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -47,4 +47,8 @@ interface JobInterface
 
 
     public function getJobDefinition(): JobDefinitionInterface;
+
+    public function planExecution(DateTimeImmutable $datetime): void;
+    public function getExecutionPlannedAt(): ?DateTimeImmutable;
+    // + trait HasExecutionPlannedAt
 }

--- a/src/Jobs/JobParameters.php
+++ b/src/Jobs/JobParameters.php
@@ -9,4 +9,5 @@ class JobParameters
     public const ATTEMPTS = 'attempts';
     public const CREATED_AT = 'createdAt';
     public const PARAMETERS = 'jobParameters';
+    public const EXECUTION_PLANNED_AT = 'executionPlannedAt';
 }

--- a/src/Queue/AWSSQS/SqsConsumer.php
+++ b/src/Queue/AWSSQS/SqsConsumer.php
@@ -112,6 +112,13 @@ class SqsConsumer implements SqsConsumerInterface
         try {
             $job = $this->jobLoader->loadJob($message->getBody());
 
+            $job->getExecutionPlannedAt();
+            if ($notYet) {
+                $this->logger->info();
+                $this->pushDelayed($job);
+                return;
+            }
+
             $this->jobExecutor->execute($job);
         } catch (DelayableProcessFailExceptionInterface $exception) {
             LoggerHelper::logDelayableProcessFailException($exception, $this->logger);


### PR DESCRIPTION
Prototype of an alternative approach to #56 

Main points:
- non-invasive, should be easy to update to without changing user code
- works out of the box for delaying SQS messages
- RabbitMQ messages are not affected at all