### PR TITLE
Improve logging of exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "doctrine/collections": "^1.5",
         "php-amqplib/php-amqplib": "^2.12.2",
         "brandembassy/datetime": "^3.0",
+        "brandembassy/logger": "^1.9.1",
         "nette/utils": "^3.0",
         "aws/aws-sdk-php": "^3.209",
         "malkusch/lock": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "doctrine/collections": "^1.5",
         "php-amqplib/php-amqplib": "^2.12.2",
         "brandembassy/datetime": "^3.0",
-        "brandembassy/logger": "^1.9.1",
         "nette/utils": "^3.0",
         "aws/aws-sdk-php": "^3.209",
         "malkusch/lock": "^2.2",

--- a/src/Logging/LoggerContextField.php
+++ b/src/Logging/LoggerContextField.php
@@ -8,7 +8,6 @@ namespace BE\QueueManagement\Logging;
 class LoggerContextField
 {
     public const EXCEPTION = 'exception';
-    public const PREVIOUS_EXCEPTION = 'previousException';
     public const JOB_EXECUTION_TIME = 'executionTime';
     public const JOB_NAME = 'job_name';
     public const JOB_UUID = 'job_uuid';

--- a/src/Logging/LoggerHelper.php
+++ b/src/Logging/LoggerHelper.php
@@ -26,8 +26,7 @@ class LoggerHelper
             $exception->getMessage(),
         );
         $context = [
-            LoggerContextField::EXCEPTION => (string)$exception,
-            LoggerContextField::PREVIOUS_EXCEPTION => (string)$exception->getPrevious(),
+            LoggerContextField::EXCEPTION => $exception,
             LoggerContextField::JOB_QUEUE_NAME => $job->getJobDefinition()->getQueueName(),
             LoggerContextField::JOB_NAME => $job->getJobDefinition()->getJobName(),
             LoggerContextField::JOB_UUID => $job->getUuid(),

--- a/src/Queue/AWSSQS/MessageDeduplication/MessageDeduplicationDefault.php
+++ b/src/Queue/AWSSQS/MessageDeduplication/MessageDeduplicationDefault.php
@@ -77,7 +77,7 @@ class MessageDeduplicationDefault implements MessageDeduplication
             $this->logger->warning(
                 'Error when releasing lock: ' . $errorMessage,
                 [
-                    LoggerContextField::EXCEPTION => (string)$exception,
+                    LoggerContextField::EXCEPTION => $exception,
                     LoggerContextField::JOB_QUEUE_NAME => $message->getQueueUrl(),
                     LoggerContextField::MESSAGE_ID => $message->getMessageId(),
                 ],
@@ -103,7 +103,7 @@ class MessageDeduplicationDefault implements MessageDeduplication
             $this->logger->error(
                 'Message duplication resolving failed',
                 [
-                    LoggerContextField::EXCEPTION => (string)$exception,
+                    LoggerContextField::EXCEPTION => $exception,
                     LoggerContextField::JOB_QUEUE_NAME => $message->getQueueUrl(),
                     LoggerContextField::MESSAGE_ID => $message->getMessageId(),
                 ],

--- a/src/Queue/AWSSQS/SqsConsumer.php
+++ b/src/Queue/AWSSQS/SqsConsumer.php
@@ -86,7 +86,7 @@ class SqsConsumer implements SqsConsumerInterface
             $this->logger->error(
                 'Consumer failed, job requeued: ' . $exception->getMessage(),
                 [
-                    LoggerContextField::EXCEPTION => (string)$exception,
+                    LoggerContextField::EXCEPTION => $exception,
                     LoggerContextField::MESSAGE_BODY => $message->getBody(),
                     LoggerContextField::MESSAGE_ID => $message->getMessageId(),
                     LoggerContextField::JOB_QUEUE_NAME => $message->getQueueUrl(),
@@ -98,7 +98,7 @@ class SqsConsumer implements SqsConsumerInterface
             $this->logger->warning(
                 'Job removed from queue: ' . $exception->getMessage(),
                 [
-                    LoggerContextField::EXCEPTION => (string)$exception,
+                    LoggerContextField::EXCEPTION => $exception,
                     LoggerContextField::MESSAGE_BODY => $message->getBody(),
                     LoggerContextField::MESSAGE_ID => $message->getMessageId(),
                     LoggerContextField::JOB_QUEUE_NAME => $message->getQueueUrl(),

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -187,7 +187,7 @@ class SqsQueueManager implements QueueManagerInterface
                 $this->logger->warning(
                     'AwsException: ' . $exception->getMessage(),
                     [
-                        LoggerContextField::EXCEPTION => (string)$exception,
+                        LoggerContextField::EXCEPTION => $exception,
                         LoggerContextField::JOB_QUEUE_NAME => $prefixedQueueName,
                     ],
                 );
@@ -300,7 +300,7 @@ class SqsQueueManager implements QueueManagerInterface
             'Reconnecting: ' . $exception->getMessage(),
             [
                 LoggerContextField::JOB_QUEUE_NAME => $prefixedQueueName,
-                LoggerContextField::EXCEPTION => (string)$exception,
+                LoggerContextField::EXCEPTION => $exception,
             ],
         );
     }


### PR DESCRIPTION
Brandembassy Logger can log exception with traces and previous exceptions since `1.9.1` (see https://github.com/BrandEmbassy/logger/pull/8 and https://github.com/BrandEmbassy/logger/pull/10).

Providing more details in the logs in a consistent manner will help with debugging.