### PR TITLE
LoggerHelper: fix usage of logJobPushedIntoQueue

### DIFF
--- a/src/Logging/LoggerHelper.php
+++ b/src/Logging/LoggerHelper.php
@@ -17,7 +17,8 @@ use function sprintf;
  */
 class LoggerHelper
 {
-    private const NOT_DELAYED = -1;
+    public const UNKNOWN_DELAY = -1;
+    public const NOT_DELAYED = 0;
 
 
     public static function logDelayableProcessFailException(DelayableProcessFailExceptionInterface $exception, LoggerInterface $logger): void
@@ -50,7 +51,7 @@ class LoggerHelper
         string $queueName,
         LoggerInterface $logger,
         ?JobType $jobType = null,
-        int $delayInSeconds = self::NOT_DELAYED
+        int $delayInSeconds = self::UNKNOWN_DELAY
     ): void {
         $logger->info(
             sprintf(

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -203,7 +203,7 @@ class SqsQueueManager implements QueueManagerInterface
         $prefixedQueueName = $this->getPrefixedQueueName($job->getJobDefinition()->getQueueName());
 
         $this->publishMessage($job->toJson(), $prefixedQueueName);
-        LoggerHelper::logJobPushedIntoQueue($job, $prefixedQueueName, $this->logger, JobType::get(JobType::SQS));
+        LoggerHelper::logJobPushedIntoQueue($job, $prefixedQueueName, $this->logger, JobType::get(JobType::SQS), LoggerHelper::NOT_DELAYED);
     }
 
 

--- a/src/Queue/RabbitMQ/RabbitMQQueueManager.php
+++ b/src/Queue/RabbitMQ/RabbitMQQueueManager.php
@@ -96,7 +96,7 @@ class RabbitMQQueueManager implements QueueManagerInterface
 
         $this->publishMessage($job->toJson(), $queueName);
 
-        LoggerHelper::logJobPushedIntoQueue($job, $queueName, $this->logger, JobType::get(JobType::RABBIT_MQ));
+        LoggerHelper::logJobPushedIntoQueue($job, $queueName, $this->logger, JobType::get(JobType::RABBIT_MQ), LoggerHelper::NOT_DELAYED);
     }
 
 


### PR DESCRIPTION
As mentioned in https://github.com/BrandEmbassy/queue-management/pull/62/files#r989850269, the default value should be unknown. If we need to use strictly `int`, I would go for `-1` being unknown and `0` being not delayed (natural meaning of delay of 0 seconds).

This avoids having "not delayed" as a default value, which would be rather bad for backward compatibility.