### PR TITLE
Fix creating UnableToProcessLoadedJobException by strict type exception code to int 

### DIFF
--- a/src/Jobs/Execution/JobExecutor.php
+++ b/src/Jobs/Execution/JobExecutor.php
@@ -61,7 +61,7 @@ class JobExecutor implements JobExecutorInterface
             throw new UnableToProcessLoadedJobException(
                 $job,
                 $exception->getMessage(),
-                $exception->getCode(),
+                (int)$exception->getCode(),
                 $exception,
             );
         }


### PR DESCRIPTION
The reason of this change is because getCode returing mixed|int value
Here is documentation:
![image](https://user-images.githubusercontent.com/6791232/203987210-98c8ed47-3423-4cc8-bf03-04fc8a65570c.png)
