### PR TITLE
DE-42559 JobExecutor: allow config of converting Throwable to UnableToProcessLoadedJobException

### DIFF
--- a/src/ThrowableFilter/AlwaysApplicableThrowableFilter.php
+++ b/src/ThrowableFilter/AlwaysApplicableThrowableFilter.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\ThrowableFilter;
+
+use Throwable;
+
+/**
+ * @final
+ */
+class AlwaysApplicableThrowableFilter implements ThrowableFilter
+{
+    public function isApplicable(Throwable $throwable): bool
+    {
+        return true;
+    }
+}

--- a/src/ThrowableFilter/NeverApplicableThrowableFilter.php
+++ b/src/ThrowableFilter/NeverApplicableThrowableFilter.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\ThrowableFilter;
+
+use Throwable;
+
+/**
+ * @final
+ */
+class NeverApplicableThrowableFilter implements ThrowableFilter
+{
+    public function isApplicable(Throwable $throwable): bool
+    {
+        return false;
+    }
+}

--- a/src/ThrowableFilter/ThrowableFilter.php
+++ b/src/ThrowableFilter/ThrowableFilter.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\ThrowableFilter;
+
+use Throwable;
+
+interface ThrowableFilter
+{
+    public function isApplicable(Throwable $throwable): bool;
+}


### PR DESCRIPTION
This change allows us to to control via DI which Throwables will get converted to `UnableToProcessLoadedJobException` in `JobExecutor`. Not allowing `Mockery` exception will help us with tests as described in https://github.com/BrandEmbassy/developers-manifest/issues/860