### PR TITLE
DE-54825 SqsMessage: Calculate message size correctly - include message attributes

### DIFF
--- a/src/Queue/AWSSQS/SqsMessage.php
+++ b/src/Queue/AWSSQS/SqsMessage.php
@@ -94,8 +94,8 @@ class SqsMessage
         $messageSize = strlen($messageBody);
         foreach ($messageAttributes as $messageAttributeKey => $messageAttribute) {
             $messageSize += strlen($messageAttributeKey);
-            $messageSize += strlen($messageAttribute['DataType']);
-            $messageSize += strlen($messageAttribute['StringValue']);
+            $messageSize += strlen($messageAttribute['DataType'] ?? '');
+            $messageSize += strlen($messageAttribute['StringValue'] ?? '');
         }
 
         return $messageSize > self::MAX_SQS_SIZE_KB * 1024;

--- a/src/Queue/AWSSQS/SqsMessage.php
+++ b/src/Queue/AWSSQS/SqsMessage.php
@@ -86,9 +86,18 @@ class SqsMessage
 
     /**
      * Returns true if message is bigger than 256 KB (AWS SQS message size limit), false otherwise
+     *
+     * @param array<string, array<string, string>> $messageAttributes
      */
-    public static function isTooBig(string $messageBody): bool
+    public static function isTooBig(string $messageBody, array $messageAttributes): bool
     {
-        return strlen($messageBody) > self::MAX_SQS_SIZE_KB * 1024;
+        $messageSize = strlen($messageBody);
+        foreach ($messageAttributes as $messageAttributeKey => $messageAttribute) {
+            $messageSize += strlen($messageAttributeKey);
+            $messageSize += strlen($messageAttribute['DataType']);
+            $messageSize += strlen($messageAttribute['StringValue']);
+        }
+
+        return $messageSize > self::MAX_SQS_SIZE_KB * 1024;
     }
 }

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -281,7 +281,17 @@ class SqsQueueManager implements QueueManagerInterface
             throw SqsClientException::createFromInvalidDelaySeconds($delaySeconds);
         }
 
-        if (SqsMessage::isTooBig($messageBody)) {
+        $messageAttributes = [
+            SqsSendingMessageFields::QUEUE_URL => [
+                'DataType' => 'String',
+                // queueName might be handy here if we want to consume
+                // from multiple queues in parallel via promises.
+                // Then we need queue in message directly so that we can delete it.
+                'StringValue' => $prefixedQueueName,
+            ],
+        ];
+
+        if (SqsMessage::isTooBig($messageBody, $messageAttributes)) {
             $key = $this->messageKeyGenerator->generate($job);
             $receipt = $this->s3Client->upload(
                 $this->s3BucketName,
@@ -295,15 +305,7 @@ class SqsQueueManager implements QueueManagerInterface
 
         $messageToSend = [
             SqsSendingMessageFields::DELAY_SECONDS => $delaySeconds,
-            SqsSendingMessageFields::MESSAGE_ATTRIBUTES => [
-                SqsSendingMessageFields::QUEUE_URL => [
-                    'DataType' => 'String',
-                    // queueName might be handy here if we want to consume
-                    // from multiple queues in parallel via promises.
-                    // Then we need queue in message directly so that we can delete it.
-                    'StringValue' => $prefixedQueueName,
-                ],
-            ],
+            SqsSendingMessageFields::MESSAGE_ATTRIBUTES => $messageAttributes,
             SqsSendingMessageFields::MESSAGE_BODY => $messageBody,
             SqsSendingMessageFields::QUEUE_URL => $prefixedQueueName,
         ];

--- a/tests/Queue/AWSSQS/SqsMessageTest.php
+++ b/tests/Queue/AWSSQS/SqsMessageTest.php
@@ -5,7 +5,7 @@ namespace Tests\BE\QueueManagement\Queue\AWSSQS;
 use BE\QueueManagement\Queue\AWSSQS\SqsMessage;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
-use function str_pad;
+use function str_repeat;
 
 /**
  * @final
@@ -43,17 +43,17 @@ class SqsMessageTest extends TestCase
         return [
             'small message' => [
                 'expectedIsTooBig' => false,
-                'messageBody' => 'very small message',
+                'messageBody' => 'message',
                 'messageAttributes' => $messageAttributes,
             ],
             'message just within the limit' => [
                 'expectedIsTooBig' => false,
-                'messageBody' => str_pad('very small message', $messageBodySizeLimit),
+                'messageBody' => str_repeat('A', $messageBodySizeLimit),
                 'messageAttributes' => $messageAttributes,
             ],
             'too big message' => [
                 'expectedIsTooBig' => true,
-                'messageBody' => str_pad('very small message', $messageBodySizeLimit + 1),
+                'messageBody' => str_repeat('A', $messageBodySizeLimit + 1),
                 'messageAttributes' => $messageAttributes,
             ],
         ];


### PR DESCRIPTION
We need to include message attributes into the calculation for too big messages.

See https://github.com/awslabs/amazon-sqs-java-extended-client-lib/blob/master/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java#L932