### PR TITLE
DE-99558 SQS consumer: Add return type to indicate job execution status

### DIFF
--- a/src/Queue/AWSSQS/SqsConsumerInterface.php
+++ b/src/Queue/AWSSQS/SqsConsumerInterface.php
@@ -2,7 +2,9 @@
 
 namespace BE\QueueManagement\Queue\AWSSQS;
 
+use BE\QueueManagement\Queue\JobExecutionStatus;
+
 interface SqsConsumerInterface
 {
-    public function __invoke(SqsMessage $message): void;
+    public function __invoke(SqsMessage $message): JobExecutionStatus;
 }

--- a/src/Queue/JobExecutionStatus.php
+++ b/src/Queue/JobExecutionStatus.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Queue;
+
+enum JobExecutionStatus
+{
+    case SUCCESS;
+    case FAILED_DELAYED;
+    case FAILED_UNRESOLVABLE;
+    case REMOVED_DUPLICATE;
+    case DELAYED_NOT_PLANNED_YET;
+}

--- a/tests/Queue/AWSSQS/SqsConsumerTest.php
+++ b/tests/Queue/AWSSQS/SqsConsumerTest.php
@@ -7,6 +7,7 @@ use BE\QueueManagement\Jobs\BlacklistedJobUuidException;
 use BE\QueueManagement\Jobs\Execution\JobExecutorInterface;
 use BE\QueueManagement\Jobs\Execution\JobLoaderInterface;
 use BE\QueueManagement\Jobs\Execution\UnableToProcessLoadedJobException;
+use BE\QueueManagement\Jobs\Execution\UnresolvableProcessFailExceptionInterface;
 use BE\QueueManagement\Jobs\FailResolving\PushDelayedResolver;
 use BE\QueueManagement\Jobs\JobDefinitions\UnknownJobDefinitionException;
 use BE\QueueManagement\Jobs\JobInterface;
@@ -14,6 +15,7 @@ use BE\QueueManagement\Queue\AWSSQS\MessageDeduplication\MessageDeduplication;
 use BE\QueueManagement\Queue\AWSSQS\MessageDeduplication\MessageDeduplicationDisabled;
 use BE\QueueManagement\Queue\AWSSQS\SqsConsumer;
 use BE\QueueManagement\Queue\AWSSQS\SqsMessage;
+use BE\QueueManagement\Queue\JobExecutionStatus;
 use BE\QueueManagement\Queue\QueueManagerInterface;
 use BrandEmbassy\DateTime\FrozenDateTimeImmutableFactory;
 use DateTimeImmutable;
@@ -22,6 +24,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use Nette\Utils\Json;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
 use Tests\BE\QueueManagement\Jobs\ExampleJob;
@@ -113,7 +116,8 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
-        $sqsConsumer($sqsMessage);
+
+        Assert::assertSame(JobExecutionStatus::SUCCESS, $sqsConsumer($sqsMessage));
     }
 
 
@@ -136,6 +140,7 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
+
         $sqsConsumer($sqsMessage);
     }
 
@@ -160,7 +165,33 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
-        $sqsConsumer($sqsMessage);
+
+        Assert::assertSame(JobExecutionStatus::FAILED_UNRESOLVABLE, $sqsConsumer($sqsMessage));
+    }
+
+
+    public function testRemoveJobWithUnresolvableExceptionFailure(): void
+    {
+        $unresolvableProcessFailException = new class() extends Exception implements UnresolvableProcessFailExceptionInterface{};
+
+        $this->jobLoaderMock->expects('loadJob')
+            ->with('{"foo":"bar"}')
+            ->andThrow(new $unresolvableProcessFailException('Unresolvable process failure.'));
+
+        $this->loggerMock->hasWarning(
+            'Job removed from queue: Unresolvable process failure.',
+        );
+
+        $this->sqsClientMock->expects('deleteMessage')
+            ->with([
+                'QueueUrl' => self::QUEUE_URL,
+                'ReceiptHandle' => self::RECEIPT_HANDLE,
+            ]);
+
+        $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
+        $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
+
+        Assert::assertSame(JobExecutionStatus::FAILED_UNRESOLVABLE, $sqsConsumer($sqsMessage));
     }
 
 
@@ -195,7 +226,8 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
-        $sqsConsumer($sqsMessage);
+
+        Assert::assertSame(JobExecutionStatus::FAILED_DELAYED, $sqsConsumer($sqsMessage));
     }
 
 
@@ -223,7 +255,8 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
-        $sqsConsumer($sqsMessage);
+
+        Assert::assertSame(JobExecutionStatus::FAILED_DELAYED, $sqsConsumer($sqsMessage));
     }
 
 
@@ -298,7 +331,8 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
-        $sqsConsumer($sqsMessage);
+
+        Assert::assertSame(JobExecutionStatus::DELAYED_NOT_PLANNED_YET, $sqsConsumer($sqsMessage));
     }
 
 
@@ -345,7 +379,8 @@ class SqsConsumerTest extends TestCase
 
         $sqsMessage = $this->createSqsMessage($this->getSqsMessageData());
         $sqsConsumer = $this->createSqsConsumer($this->sqsClientMock);
-        $sqsConsumer($sqsMessage);
+
+        Assert::assertSame(JobExecutionStatus::SUCCESS, $sqsConsumer($sqsMessage));
     }
 
 


### PR DESCRIPTION
This change will help us mainly during testing. We will be able to assert if a job execution ended up as expected.

![image](https://github.com/BrandEmbassy/queue-management/assets/38032505/73f4d4f2-749c-4a7c-a5cf-0bb4f8731268)
