### PR TITLE
DE-106540 Add support for delayed message schedulers

### DIFF
--- a/src/Queue/AWSSQS/DelayedJobSchedulerInterface.php
+++ b/src/Queue/AWSSQS/DelayedJobSchedulerInterface.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Queue\AWSSQS;
+
+use BE\QueueManagement\Jobs\JobInterface;
+
+interface DelayedJobSchedulerInterface
+{
+    public function getSchedulerName(): string;
+
+
+    public function scheduleJob(JobInterface $job, string $prefixedQueueName): string;
+}

--- a/tests/Jobs/ExampleJob.php
+++ b/tests/Jobs/ExampleJob.php
@@ -15,7 +15,7 @@ use function str_repeat;
  */
 class ExampleJob extends SimpleJob
 {
-    public const UUID = 'some-job-uud';
+    public const UUID = 'some-job-uuid';
 
     public const ATTEMPTS = JobInterface::INIT_ATTEMPTS;
 

--- a/tests/Queue/AWSSQS/SqsConsumerTest.php
+++ b/tests/Queue/AWSSQS/SqsConsumerTest.php
@@ -155,7 +155,7 @@ class SqsConsumerTest extends TestCase
             ->andThrow($blacklistedJobUuidException);
 
         $this->loggerMock->hasWarning(
-            'Job removed from queue: Job some-job-uud blacklisted',
+            'Job removed from queue: Job some-job-uuid blacklisted',
         );
 
         $this->sqsClientMock->expects('deleteMessage')

--- a/tests/Queue/AWSSQS/SqsQueueManagerTest.php
+++ b/tests/Queue/AWSSQS/SqsQueueManagerTest.php
@@ -80,7 +80,7 @@ class SqsQueueManagerTest extends TestCase
     {
         $queueManager = $this->createQueueManagerWithExpectations($queueNamePrefix);
 
-        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
+        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uuid] pushed into exampleJobQueue queue');
 
         $exampleJob = $this->createExampleJob($queueName);
 
@@ -101,7 +101,7 @@ class SqsQueueManagerTest extends TestCase
     {
         $queueManager = $this->createQueueManagerWithExpectations($queueNamePrefix);
 
-        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
+        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uuid] pushed into exampleJobQueue queue');
 
         $exampleJobWithInvalidCharacter = new ExampleJob(
             ExampleJobDefinition::create()
@@ -136,7 +136,7 @@ class SqsQueueManagerTest extends TestCase
     {
         $queueManager = $this->createQueueManagerWithExpectations($queueNamePrefix);
 
-        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
+        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uuid] pushed into exampleJobQueue queue');
 
         $exampleJob = ExampleJob::createTooBigForSqs(
             ExampleJobDefinition::create()
@@ -188,7 +188,7 @@ class SqsQueueManagerTest extends TestCase
             )
             ->andReturn($this->createSqsSendMessageResultMock());
 
-        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
+        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uuid] pushed into exampleJobQueue queue');
 
         $queueManager->pushDelayed($exampleJob, 5);
     }
@@ -202,7 +202,7 @@ class SqsQueueManagerTest extends TestCase
         $exampleJob = $this->createExampleJob($queueName);
 
         $expectedMessageBody = [
-            'jobUuid' => 'some-job-uud',
+            'jobUuid' => 'some-job-uuid',
             'jobName' => 'exampleJob',
             'attempts' => 1,
             'createdAt' => '2018-08-01T10:15:47+01:00',
@@ -225,7 +225,7 @@ class SqsQueueManagerTest extends TestCase
         $this->loggerMock->hasInfo(
             'Requested delay is greater than SQS limit. Job execution has been planned and will be requeued until then.',
         );
-        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
+        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uuid] pushed into exampleJobQueue queue');
 
         $queueManager->pushDelayed($exampleJob, 1800);
     }
@@ -255,7 +255,7 @@ class SqsQueueManagerTest extends TestCase
     {
         $queueManager = $this->createQueueManagerWithExpectations($queueNamePrefix, 2);
 
-        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uud] pushed into exampleJobQueue queue');
+        $this->loggerMock->hasInfo('Job (exampleJob) [some-job-uuid] pushed into exampleJobQueue queue');
 
         $exampleJob = $this->createExampleJob($queueName);
 


### PR DESCRIPTION
The way this is going to work with the FT's on PB is that we will have 2 instances of `SqsQueueManager`, one with and other without `DelayedJobScheduler`. Depending on FT's, one or the other would be used.