### PR TITLE
DE-106539 Fixes for make max delay in seconds configurable

### DIFF
--- a/src/Queue/AWSSQS/SqsConsumer.php
+++ b/src/Queue/AWSSQS/SqsConsumer.php
@@ -148,7 +148,11 @@ class SqsConsumer implements SqsConsumerInterface
 
                 if ($timeRemainsInSeconds > 0) {
                     $this->logSqsDelayJob($job, $timeRemainsInSeconds);
-                    $this->queueManager->pushDelayed($job, $timeRemainsInSeconds);
+                    $this->queueManager->pushDelayed(
+                        $job,
+                        $timeRemainsInSeconds,
+                        SqsQueueManager::MAX_DELAY_IN_SECONDS,
+                    );
 
                     return JobExecutionStatus::DELAYED_NOT_PLANNED_YET;
                 }

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -40,12 +40,12 @@ class SqsQueueManager implements QueueManagerInterface
 
     public const CONSUME_LOOP_ITERATIONS_NO_LIMIT = -1;
 
+    // SQS allows maximum message delay of 15 minutes
+    public const MAX_DELAY_IN_SECONDS = 15 * 60;
+
     private const WAIT_TIME_SECONDS = 'WaitTimeSeconds';
 
     private const DELAY_SECONDS = 'DelaySeconds';
-
-    // SQS allows maximum message delay of 15 minutes
-    private const MAX_DELAY_IN_SECONDS = 15 * 60;
 
     private string $s3BucketName;
 
@@ -240,8 +240,8 @@ class SqsQueueManager implements QueueManagerInterface
     public function pushDelayed(JobInterface $job, int $delayInSeconds, int $maxDelayInSeconds = self::MAX_DELAY_IN_SECONDS): void
     {
         assert(
-            $maxDelayInSeconds > 0,
-            'Argument $maxDelayInSeconds must be greater than 0',
+            $maxDelayInSeconds >= 0,
+            'Argument $maxDelayInSeconds must be greater or equal to 0',
         );
 
         $prefixedQueueName = $this->getPrefixedQueueName($job->getJobDefinition()->getQueueName());

--- a/src/Queue/QueueManagerInterface.php
+++ b/src/Queue/QueueManagerInterface.php
@@ -15,7 +15,13 @@ interface QueueManagerInterface
     public function push(JobInterface $job): void;
 
 
-    public function pushDelayed(JobInterface $job, int $delayInSeconds): void;
+    /**
+     * @param int $maxDelayInSeconds This parameter can be used to override the default maximum delay before using
+     *                               delayed job scheduler (if one is configured). This can be useful for
+     *                               implementation of automated tests & synthetic monitoring of delayed job
+     *                               scheduler on live environments while maintaining quick feedback loop.
+     */
+    public function pushDelayed(JobInterface $job, int $delayInSeconds, int $maxDelayInSeconds): void;
 
 
     public function pushDelayedWithMilliseconds(JobInterface $job, int $delayInMilliseconds): void;

--- a/tests/Queue/AWSSQS/SqsConsumerTest.php
+++ b/tests/Queue/AWSSQS/SqsConsumerTest.php
@@ -15,6 +15,7 @@ use BE\QueueManagement\Queue\AWSSQS\MessageDeduplication\MessageDeduplication;
 use BE\QueueManagement\Queue\AWSSQS\MessageDeduplication\MessageDeduplicationDisabled;
 use BE\QueueManagement\Queue\AWSSQS\SqsConsumer;
 use BE\QueueManagement\Queue\AWSSQS\SqsMessage;
+use BE\QueueManagement\Queue\AWSSQS\SqsQueueManager;
 use BE\QueueManagement\Queue\JobExecutionStatus;
 use BE\QueueManagement\Queue\QueueManagerInterface;
 use BrandEmbassy\DateTime\FrozenDateTimeImmutableFactory;
@@ -319,7 +320,7 @@ class SqsConsumerTest extends TestCase
             ->andReturn($exampleJob);
 
         $this->queueManagerMock->expects('pushDelayed')
-            ->with($exampleJob, $expectedDelay);
+            ->with($exampleJob, $expectedDelay, SqsQueueManager::MAX_DELAY_IN_SECONDS);
 
         $this->sqsClientMock->expects('deleteMessage')
             ->with([


### PR DESCRIPTION
I forgot to update the interface. By adding argument to the interface, following phpstan error is solved:
![image](https://github.com/user-attachments/assets/cd1db77c-7fc3-4f8a-8306-884a49ae7f0c)
But it is replaced by this one, which was discussed in [phpstan issue "Support for optional backward compatibility arguments in interfaces"](https://github.com/phpstan/phpstan/issues/3779) and closed as working as intended, use ignore errors in this situations:
![image](https://github.com/user-attachments/assets/4eda8137-80c8-4fbb-9bbe-d0820468a59f)

To avoid having to use ignore errors, I am making `MAX_DELAY_IN_SECONDS` public so caller can always use it in 3rd argument if he wants to (or just add the phpstan error to ignore errors).

Also, we want to allow `$maxDelayInSeconds` to be 0, so that you can theoretically also catch messages with 1 second scheduled delay (since the condition check is `if ($delayInSeconds > $maxDelayInSeconds) { ...`)