### PR TITLE
DE-111852 Add support for custom SQS message attributes

### DIFF
--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -61,4 +61,16 @@ interface JobInterface
 
 
     public function setExecutionPlannedAt(DateTimeImmutable $executionPlannedAt): void;
+
+
+    /**
+     * @return array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}>
+     */
+    public function getMessageAttributes(): array;
+
+
+    /**
+     * @param array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}> $messageAttributes
+     */
+    public function setMessageAttributes(array $messageAttributes): void;
 }

--- a/src/Queue/AWSSQS/SqsMessageAttributeDataType.php
+++ b/src/Queue/AWSSQS/SqsMessageAttributeDataType.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Queue\AWSSQS;
+
+enum SqsMessageAttributeDataType: string
+{
+    case STRING = 'String';
+
+    case NUMBER = 'Number';
+
+    case BINARY = 'Binary';
+}

--- a/src/Queue/AWSSQS/SqsMessageAttributeFields.php
+++ b/src/Queue/AWSSQS/SqsMessageAttributeFields.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Queue\AWSSQS;
+
+enum SqsMessageAttributeFields: string
+{
+    case DATA_TYPE = 'DataType';
+
+    case BINARY_VALUE = 'BinaryValue';
+
+    case STRING_VALUE = 'StringValue';
+}

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -413,14 +413,13 @@ class SqsQueueManager implements QueueManagerInterface
             throw SqsClientException::createFromInvalidDelaySeconds($delaySeconds);
         }
 
-        $messageAttributes = [
-            SqsSendingMessageFields::QUEUE_URL => [
-                'DataType' => 'String',
-                // queueName might be handy here if we want to consume
-                // from multiple queues in parallel via promises.
-                // Then we need queue in message directly so that we can delete it.
-                'StringValue' => $prefixedQueueName,
-            ],
+        $messageAttributes = $job->getMessageAttributes();
+        $messageAttributes[SqsSendingMessageFields::QUEUE_URL] = [
+            SqsMessageAttributeFields::DATA_TYPE->value => SqsMessageAttributeDataType::STRING->value,
+            // queueName might be handy here if we want to consume
+            // from multiple queues in parallel via promises.
+            // Then we need queue in message directly so that we can delete it.
+            SqsMessageAttributeFields::STRING_VALUE->value => $prefixedQueueName,
         ];
 
         if (SqsMessage::isTooBig($messageBody, $messageAttributes)) {

--- a/tests/Jobs/ExampleJob.php
+++ b/tests/Jobs/ExampleJob.php
@@ -28,8 +28,14 @@ class ExampleJob extends SimpleJob
     public const PARAMETER_FOO = 'foo';
 
 
-    public function __construct(?JobDefinitionInterface $jobDefinition = null, string $bar = 'bar')
-    {
+    /**
+     * @param array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}> $messageAttributes
+     */
+    public function __construct(
+        ?JobDefinitionInterface $jobDefinition = null,
+        string $bar = 'bar',
+        array $messageAttributes = [],
+    ) {
         /**
          * Prevent phpstan error Template type T on class Doctrine\Common\Collections\Collection is not covariant
          * @var array<string,mixed> $parameters
@@ -43,6 +49,7 @@ class ExampleJob extends SimpleJob
             $jobDefinition ?? ExampleJobDefinition::create(),
             new ArrayCollection($parameters),
             null,
+            $messageAttributes,
         );
     }
 


### PR DESCRIPTION
Allow passing of custom sqs message attributes. Example use case would be to pass observability related metadata from the initial http request down to the asynchronous processs / job.