### PR TITLE
DE-111852 Add support for custom SQS message attributes - part 02

### DIFF
--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -3,6 +3,7 @@
 namespace BE\QueueManagement\Jobs;
 
 use BE\QueueManagement\Jobs\JobDefinitions\JobDefinitionInterface;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
 use DateTimeImmutable;
 
 interface JobInterface
@@ -73,4 +74,17 @@ interface JobInterface
      * @param array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}> $messageAttributes
      */
     public function setMessageAttributes(array $messageAttributes): void;
+
+
+    public function getMessageAttribute(
+        string $messageAttributeName,
+        SqsMessageAttributeDataType $messageAttributeDataType = SqsMessageAttributeDataType::STRING
+    ): string|int|float|null;
+
+
+    public function setMessageAttribute(
+        string $messageAttributeName,
+        string|int|float $messageAttributeValue,
+        SqsMessageAttributeDataType $messageAttributeDataType = SqsMessageAttributeDataType::STRING
+    ): void;
 }

--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -3,7 +3,7 @@
 namespace BE\QueueManagement\Jobs;
 
 use BE\QueueManagement\Jobs\JobDefinitions\JobDefinitionInterface;
-use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttribute;
 use DateTimeImmutable;
 
 interface JobInterface
@@ -65,26 +65,23 @@ interface JobInterface
 
 
     /**
-     * @return array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}>
+     * @return array<string,SqsMessageAttribute>
      */
     public function getMessageAttributes(): array;
 
 
     /**
-     * @param array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}> $messageAttributes
+     * @param array<string,SqsMessageAttribute> $messageAttributes
      */
     public function setMessageAttributes(array $messageAttributes): void;
 
 
     public function getMessageAttribute(
         string $messageAttributeName,
-        SqsMessageAttributeDataType $messageAttributeDataType = SqsMessageAttributeDataType::STRING
-    ): string|int|float|null;
+    ): SqsMessageAttribute|null;
 
 
     public function setMessageAttribute(
-        string $messageAttributeName,
-        string|int|float $messageAttributeValue,
-        SqsMessageAttributeDataType $messageAttributeDataType = SqsMessageAttributeDataType::STRING
+        SqsMessageAttribute $sqsMessageAttribute,
     ): void;
 }

--- a/src/Observability/AfterMessageSentEvent.php
+++ b/src/Observability/AfterMessageSentEvent.php
@@ -2,7 +2,7 @@
 
 namespace BE\QueueManagement\Observability;
 
-class MessageSentEvent
+class AfterMessageSentEvent
 {
     /**
      * @param mixed[] $messageAttributes

--- a/src/Observability/BeforeMessageSentEvent.php
+++ b/src/Observability/BeforeMessageSentEvent.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Observability;
+
+use BE\QueueManagement\Jobs\JobInterface;
+
+class BeforeMessageSentEvent
+{
+    public function __construct(
+        public readonly JobInterface $job,
+        public readonly int $delayInSeconds,
+        public readonly string $prefixedQueueName,
+    ) {
+    }
+}

--- a/src/Queue/AWSSQS/SqsMessageAttribute.php
+++ b/src/Queue/AWSSQS/SqsMessageAttribute.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Queue\AWSSQS;
+
+use function is_numeric;
+use function str_contains;
+use function strlen;
+
+/**
+ * Represent SQS Message Attribute
+ *
+ * @final
+ */
+class SqsMessageAttribute
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly string $value,
+        private readonly SqsMessageAttributeDataType $dataType,
+    ) {
+    }
+
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+
+    public function getValue(): string|int|float
+    {
+        if ($this->dataType === SqsMessageAttributeDataType::NUMBER) {
+            if (is_numeric($this->value)) {
+                if (str_contains($this->value, '.')) {
+                    return (float)$this->value;
+                }
+
+                return (int)$this->value;
+            }
+        }
+
+        return $this->value;
+    }
+
+
+    public function getDataType(): SqsMessageAttributeDataType
+    {
+        return $this->dataType;
+    }
+
+
+    public function getSizeInBytes(): int
+    {
+        return strlen($this->dataType->value) + strlen($this->value);
+    }
+
+
+    /**
+     * @return array{DataType: 'String'|'Number', StringValue: string}|array{DataType: 'Binary', BinaryValue: string}
+     */
+    public function toArray(): array
+    {
+        if ($this->dataType === SqsMessageAttributeDataType::BINARY) {
+            return [
+                SqsMessageAttributeFields::DATA_TYPE->value => $this->dataType->value,
+                SqsMessageAttributeFields::BINARY_VALUE->value => $this->value,
+            ];
+        }
+
+        return [
+            SqsMessageAttributeFields::DATA_TYPE->value => $this->dataType->value,
+            SqsMessageAttributeFields::STRING_VALUE->value => $this->value,
+        ];
+    }
+}

--- a/src/Queue/AWSSQS/SqsMessageAttributeFactory.php
+++ b/src/Queue/AWSSQS/SqsMessageAttributeFactory.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace BE\QueueManagement\Queue\AWSSQS;
+
+/**
+ * @final
+ */
+class SqsMessageAttributeFactory
+{
+    /**
+     * @param array{DataType: 'String'|'Number', StringValue: string}|array{DataType: 'Binary', BinaryValue: string} $value
+     */
+    public function createFromArray(string $name, array $value): SqsMessageAttribute
+    {
+        $dataType = SqsMessageAttributeDataType::from($value[SqsMessageAttributeFields::DATA_TYPE->value]);
+        $valueKey = $dataType === SqsMessageAttributeDataType::BINARY
+            ? SqsMessageAttributeFields::BINARY_VALUE->value
+            : SqsMessageAttributeFields::STRING_VALUE->value;
+
+        return new SqsMessageAttribute(
+            $name,
+            $value[$valueKey],
+            $dataType,
+        );
+    }
+}

--- a/src/Queue/AWSSQS/SqsQueueManager.php
+++ b/src/Queue/AWSSQS/SqsQueueManager.php
@@ -312,17 +312,15 @@ class SqsQueueManager implements QueueManagerInterface
 
         $sqsMessageId = $this->publishMessage($job, $prefixedQueueName, $parameters);
 
-        if ($this->eventDispatcher !== null) {
-            $this->eventDispatcher->dispatch(new AfterExecutionPlannedEvent(
-                $beforeExecutionPlannedEvent->executionPlannedId,
-                $job,
-                $prefixedQueueName,
-                $delayInSeconds,
-                PlannedExecutionStrategyEnum::SQS_DELIVERY_DELAY,
-                null,
-                $sqsMessageId,
-            ));
-        }
+        $this->eventDispatcher?->dispatch(new AfterExecutionPlannedEvent(
+            $beforeExecutionPlannedEvent->executionPlannedId ?? Uuid::uuid4(),
+            $job,
+            $prefixedQueueName,
+            $delayInSeconds,
+            PlannedExecutionStrategyEnum::SQS_DELIVERY_DELAY,
+            null,
+            $sqsMessageId,
+        ));
 
         LoggerHelper::logJobPushedIntoQueue(
             $job,
@@ -373,17 +371,15 @@ class SqsQueueManager implements QueueManagerInterface
             ],
         );
 
-        if ($this->eventDispatcher !== null) {
-            $this->eventDispatcher->dispatch(new AfterExecutionPlannedEvent(
-                $beforeExecutionPlannedEvent->executionPlannedId,
-                $job,
-                $prefixedQueueName,
-                $delayInSeconds,
-                PlannedExecutionStrategyEnum::DELAYED_JOB_SCHEDULER,
-                $scheduledEventId,
-                null,
-            ));
-        }
+        $this->eventDispatcher?->dispatch(new AfterExecutionPlannedEvent(
+            $beforeExecutionPlannedEvent->executionPlannedId ?? Uuid::uuid4(),
+            $job,
+            $prefixedQueueName,
+            $delayInSeconds,
+            PlannedExecutionStrategyEnum::DELAYED_JOB_SCHEDULER,
+            $scheduledEventId,
+            null,
+        ));
     }
 
 
@@ -414,13 +410,11 @@ class SqsQueueManager implements QueueManagerInterface
             throw SqsClientException::createFromInvalidDelaySeconds($delaySeconds);
         }
 
-        if ($this->eventDispatcher !== null) {
-            $this->eventDispatcher->dispatch(new BeforeMessageSentEvent(
-                $job,
-                $delaySeconds,
-                $prefixedQueueName,
-            ));
-        }
+        $this->eventDispatcher?->dispatch(new BeforeMessageSentEvent(
+            $job,
+            $delaySeconds,
+            $prefixedQueueName,
+        ));
 
         $messageAttributes = $job->getMessageAttributes();
         $messageAttributes[SqsSendingMessageFields::QUEUE_URL] = [
@@ -468,14 +462,12 @@ class SqsQueueManager implements QueueManagerInterface
         $result = $this->sqsClient->sendMessage($messageToSend);
         $messageId = $result->get(SqsMessageFields::MESSAGE_ID);
 
-        if ($this->eventDispatcher !== null) {
-            $this->eventDispatcher->dispatch(new AfterMessageSentEvent(
-                $messageToSend[SqsSendingMessageFields::DELAY_SECONDS],
-                $messageId,
-                $messageToSend[SqsSendingMessageFields::MESSAGE_ATTRIBUTES],
-                $messageToSend[SqsSendingMessageFields::MESSAGE_BODY],
-            ));
-        }
+        $this->eventDispatcher?->dispatch(new AfterMessageSentEvent(
+            $messageToSend[SqsSendingMessageFields::DELAY_SECONDS],
+            $messageId,
+            $messageToSend[SqsSendingMessageFields::MESSAGE_ATTRIBUTES],
+            $messageToSend[SqsSendingMessageFields::MESSAGE_BODY],
+        ));
 
         return $messageId;
     }

--- a/tests/Jobs/ExampleJob.php
+++ b/tests/Jobs/ExampleJob.php
@@ -5,6 +5,7 @@ namespace Tests\BE\QueueManagement\Jobs;
 use BE\QueueManagement\Jobs\JobDefinitions\JobDefinitionInterface;
 use BE\QueueManagement\Jobs\JobInterface;
 use BE\QueueManagement\Jobs\SimpleJob;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttribute;
 use BrandEmbassy\DateTime\DateTimeFromString;
 use Doctrine\Common\Collections\ArrayCollection;
 use Tests\BE\QueueManagement\Jobs\JobDefinitions\ExampleJobDefinition;
@@ -29,7 +30,7 @@ class ExampleJob extends SimpleJob
 
 
     /**
-     * @param array<string,array{DataType: string, StringValue?: string, BinaryValue?: string}> $messageAttributes
+     * @param array<string,SqsMessageAttribute> $messageAttributes
      */
     public function __construct(
         ?JobDefinitionInterface $jobDefinition = null,

--- a/tests/Jobs/SimpleJobTest.php
+++ b/tests/Jobs/SimpleJobTest.php
@@ -4,6 +4,7 @@ namespace Tests\BE\QueueManagement\Jobs;
 
 use BE\QueueManagement\Jobs\JobDefinitions\JobDefinitionInterface;
 use BE\QueueManagement\Jobs\SimpleJob;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttribute;
 use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -39,60 +40,49 @@ class SimpleJobTest extends TestCase
 
     #[DataProvider('getSetMessageAttributeDataProvider')]
     public function testSetAndGetMessageAttribute(
-        string $messageAttributeName,
-        ?string $messageAttributeValue,
-        SqsMessageAttributeDataType $messageAttributeDataType,
+        SqsMessageAttribute $sqsMessageAttribute,
         string|int|float|null $expectedResult
     ): void {
-        if ($messageAttributeValue !== null) {
-            $this->job->setMessageAttribute(
-                $messageAttributeName,
-                $messageAttributeValue,
-                $messageAttributeDataType,
-            );
-        }
+        $this->job->setMessageAttribute($sqsMessageAttribute);
 
-        $result = $this->job->getMessageAttribute($messageAttributeName, $messageAttributeDataType);
-        Assert::assertSame($expectedResult, $result);
+        $result = $this->job->getMessageAttribute($sqsMessageAttribute->getName());
+        Assert::assertSame($expectedResult, $result?->getValue());
     }
 
 
     /**
      * @return Iterator<string,array{
-     *     messageAttributeName: string,
-     *     messageAttributeValue: ?string,
-     *     messageAttributeDataType: SqsMessageAttributeDataType,
-     *     expectedResult: string|int|float|null,
+     *     sqsMessageAttribute: SqsMessageAttribute,
+     *     expectedResult: string|int|float,
      * }>
      */
     public static function getSetMessageAttributeDataProvider(): Iterator
     {
         yield 'string attribute' => [
-            'messageAttributeName' => 'exampleString',
-            'messageAttributeValue' => 'Hello, World!',
-            'messageAttributeDataType' => SqsMessageAttributeDataType::STRING,
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleString',
+                'Hello, World!',
+                SqsMessageAttributeDataType::STRING,
+            ),
             'expectedResult' => 'Hello, World!',
         ];
 
         yield 'integer attribute' => [
-            'messageAttributeName' => 'exampleNumberInt',
-            'messageAttributeValue' => '123',
-            'messageAttributeDataType' => SqsMessageAttributeDataType::NUMBER,
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleNumberInt',
+                '123',
+                SqsMessageAttributeDataType::NUMBER,
+            ),
             'expectedResult' => 123,
         ];
 
         yield 'float attribute' => [
-            'messageAttributeName' => 'exampleNumberFloat',
-            'messageAttributeValue' => '123.45',
-            'messageAttributeDataType' => SqsMessageAttributeDataType::NUMBER,
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleNumberFloat',
+                '123.45',
+                SqsMessageAttributeDataType::NUMBER,
+            ),
             'expectedResult' => 123.45,
-        ];
-
-        yield 'attribute not set' => [
-            'messageAttributeName' => 'exampleNumberFloat',
-            'messageAttributeValue' => null,
-            'messageAttributeDataType' => SqsMessageAttributeDataType::STRING,
-            'expectedResult' => null,
         ];
     }
 }

--- a/tests/Jobs/SimpleJobTest.php
+++ b/tests/Jobs/SimpleJobTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\BE\QueueManagement\Jobs;
+
+use BE\QueueManagement\Jobs\JobDefinitions\JobDefinitionInterface;
+use BE\QueueManagement\Jobs\SimpleJob;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Iterator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SimpleJobTest extends TestCase
+{
+    private SimpleJob $job;
+
+
+    protected function setUp(): void
+    {
+        $uuid = '123-456';
+        $createdAt = new DateTimeImmutable();
+        $attempts = 1;
+        $jobDefinition = $this->createMock(JobDefinitionInterface::class);
+        $parameters = new ArrayCollection();
+        $executionPlannedAt = new DateTimeImmutable();
+
+        $this->job = new SimpleJob(
+            $uuid,
+            $createdAt,
+            $attempts,
+            $jobDefinition,
+            $parameters,
+            $executionPlannedAt,
+        );
+    }
+
+
+    #[DataProvider('getSetMessageAttributeDataProvider')]
+    public function testSetAndGetMessageAttribute(
+        string $messageAttributeName,
+        ?string $messageAttributeValue,
+        SqsMessageAttributeDataType $messageAttributeDataType,
+        string|int|float|null $expectedResult
+    ): void {
+        if ($messageAttributeValue !== null) {
+            $this->job->setMessageAttribute(
+                $messageAttributeName,
+                $messageAttributeValue,
+                $messageAttributeDataType,
+            );
+        }
+
+        $result = $this->job->getMessageAttribute($messageAttributeName, $messageAttributeDataType);
+        Assert::assertSame($expectedResult, $result);
+    }
+
+
+    /**
+     * @return Iterator<string,array{
+     *     messageAttributeName: string,
+     *     messageAttributeValue: ?string,
+     *     messageAttributeDataType: SqsMessageAttributeDataType,
+     *     expectedResult: string|int|float|null,
+     * }>
+     */
+    public static function getSetMessageAttributeDataProvider(): Iterator
+    {
+        yield 'string attribute' => [
+            'messageAttributeName' => 'exampleString',
+            'messageAttributeValue' => 'Hello, World!',
+            'messageAttributeDataType' => SqsMessageAttributeDataType::STRING,
+            'expectedResult' => 'Hello, World!',
+        ];
+
+        yield 'integer attribute' => [
+            'messageAttributeName' => 'exampleNumberInt',
+            'messageAttributeValue' => '123',
+            'messageAttributeDataType' => SqsMessageAttributeDataType::NUMBER,
+            'expectedResult' => 123,
+        ];
+
+        yield 'float attribute' => [
+            'messageAttributeName' => 'exampleNumberFloat',
+            'messageAttributeValue' => '123.45',
+            'messageAttributeDataType' => SqsMessageAttributeDataType::NUMBER,
+            'expectedResult' => 123.45,
+        ];
+
+        yield 'attribute not set' => [
+            'messageAttributeName' => 'exampleNumberFloat',
+            'messageAttributeValue' => null,
+            'messageAttributeDataType' => SqsMessageAttributeDataType::STRING,
+            'expectedResult' => null,
+        ];
+    }
+}

--- a/tests/Queue/AWSSQS/SqsConsumerTest.php
+++ b/tests/Queue/AWSSQS/SqsConsumerTest.php
@@ -15,6 +15,8 @@ use BE\QueueManagement\Queue\AWSSQS\MessageDeduplication\MessageDeduplication;
 use BE\QueueManagement\Queue\AWSSQS\MessageDeduplication\MessageDeduplicationDisabled;
 use BE\QueueManagement\Queue\AWSSQS\SqsConsumer;
 use BE\QueueManagement\Queue\AWSSQS\SqsMessage;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttribute;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
 use BE\QueueManagement\Queue\AWSSQS\SqsQueueManager;
 use BE\QueueManagement\Queue\JobExecutionStatus;
 use BE\QueueManagement\Queue\QueueManagerInterface;
@@ -37,6 +39,7 @@ use Tests\BE\QueueManagement\Jobs\Execution\ExampleWarningOnlyException;
 use Throwable;
 
 /**
+ * @phpstan-import-type TSqsMessage from SqsMessage
  * @final
  */
 class SqsConsumerTest extends TestCase
@@ -404,17 +407,19 @@ class SqsConsumerTest extends TestCase
 
 
     /**
-     * @return array<string, mixed>
+     * @return TSqsMessage
      */
     private function getSqsMessageData(): array
     {
         return [
             'MessageId' => self::MESSAGE_ID,
+            'Attributes' => [],
             'MessageAttributes' => [
-                'QueueUrl' => [
-                    'DataType' => 'String',
-                    'StringValue' => self::QUEUE_URL,
-                ],
+                'QueueUrl' => new SqsMessageAttribute(
+                    'QueueUrl',
+                    self::QUEUE_URL,
+                    SqsMessageAttributeDataType::STRING,
+                ),
             ],
             'Body' => Json::encode(['foo' => 'bar']),
             'ReceiptHandle' => self::RECEIPT_HANDLE,
@@ -423,7 +428,7 @@ class SqsConsumerTest extends TestCase
 
 
     /**
-     * @param mixed[] $messageData
+     * @param TSqsMessage $messageData
      */
     private function createSqsMessage(array $messageData): SqsMessage
     {

--- a/tests/Queue/AWSSQS/SqsMessageAttributeFactoryTest.php
+++ b/tests/Queue/AWSSQS/SqsMessageAttributeFactoryTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types = 1);
+
+namespace Queue\AWSSQS;
+
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttribute;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeFactory;
+use Iterator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @final
+ */
+class SqsMessageAttributeFactoryTest extends TestCase
+{
+    /**
+     * @param array{DataType: 'String'|'Number', StringValue: string}|array{DataType: 'Binary', BinaryValue: string} $messageAttributeValue
+     */
+    #[DataProvider('createFromArrayDataProvider')]
+    public function testCreateFromArray(
+        string $messageAttributeName,
+        array $messageAttributeValue,
+        SqsMessageAttribute $expectedSqsMessageAttribute
+    ): void {
+        $sqsMessageAttributeFactory = new SqsMessageAttributeFactory();
+
+        $sqsMessageAttribute = $sqsMessageAttributeFactory->createFromArray($messageAttributeName, $messageAttributeValue);
+
+        Assert::assertEquals($expectedSqsMessageAttribute, $sqsMessageAttribute);
+    }
+
+
+    /**
+     * @return Iterator<string,array{
+     *     messageAttributeName: string,
+     *     messageAttributeValue: array{DataType: 'String'|'Number', StringValue: string}|array{DataType: 'Binary', BinaryValue: string},
+     *     expectedSqsMessageAttribute: SqsMessageAttribute,
+     * }>
+     */
+    public static function createFromArrayDataProvider(): Iterator
+    {
+        yield 'string attribute' => [
+            'messageAttributeName' => 'exampleString',
+            'messageAttributeValue' => [
+                'DataType' => 'String',
+                'StringValue' => 'Hello, World!',
+            ],
+            'expectedSqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleString',
+                'Hello, World!',
+                SqsMessageAttributeDataType::STRING,
+            ),
+        ];
+
+        yield 'integer attribute' => [
+            'messageAttributeName' => 'exampleNumberInt',
+            'messageAttributeValue' => [
+                'DataType' => 'Number',
+                'StringValue' => '123',
+            ],
+            'expectedSqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleNumberInt',
+                '123',
+                SqsMessageAttributeDataType::NUMBER,
+            ),
+        ];
+
+        yield 'float attribute' => [
+            'messageAttributeName' => 'exampleNumberFloat',
+            'messageAttributeValue' => [
+                'DataType' => 'Number',
+                'StringValue' => '123.45',
+            ],
+            'expectedSqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleNumberFloat',
+                '123.45',
+                SqsMessageAttributeDataType::NUMBER,
+            ),
+        ];
+
+        yield 'binary attribute' => [
+            'messageAttributeName' => 'exampleBinary',
+            'messageAttributeValue' => [
+                'DataType' => 'Binary',
+                'BinaryValue' => 'abc',
+            ],
+            'expectedSqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleBinary',
+                'abc',
+                SqsMessageAttributeDataType::BINARY,
+            ),
+        ];
+    }
+}

--- a/tests/Queue/AWSSQS/SqsMessageAttributeTest.php
+++ b/tests/Queue/AWSSQS/SqsMessageAttributeTest.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types = 1);
+
+namespace Queue\AWSSQS;
+
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttribute;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
+use Iterator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @final
+ */
+class SqsMessageAttributeTest extends TestCase
+{
+    /**
+     * @param array{DataType: 'String'|'Number', StringValue: string}|array{DataType: 'Binary', BinaryValue: string} $expectedArray
+     */
+    #[DataProvider('sqsMessageAttributeDataProvider')]
+    public function testSqsMessageAttribute(
+        SqsMessageAttribute $sqsMessageAttribute,
+        string|int|float $expectedSqsMessageAttributeValue,
+        array $expectedArray,
+        int $expectedSizeInBytes,
+    ): void {
+        Assert::assertSame($expectedSqsMessageAttributeValue, $sqsMessageAttribute->getValue());
+        Assert::assertSame($expectedArray, $sqsMessageAttribute->toArray());
+        Assert::assertSame($expectedSizeInBytes, $sqsMessageAttribute->getSizeInBytes());
+    }
+
+
+    /**
+     * @return Iterator<string,array{
+     *     sqsMessageAttribute: SqsMessageAttribute,
+     *     expectedSqsMessageAttributeValue: string|int|float,
+     *     expectedArray: array{DataType: 'String'|'Number', StringValue: string}|array{DataType: 'Binary', BinaryValue: string},
+     *     expectedSizeInBytes: int,
+     * }>
+     */
+    public static function sqsMessageAttributeDataProvider(): Iterator
+    {
+        yield 'string attribute' => [
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleString',
+                'Hello, World!',
+                SqsMessageAttributeDataType::STRING,
+            ),
+            'expectedSqsMessageAttributeValue' => 'Hello, World!',
+            'expectedArray' => [
+                'DataType' => 'String',
+                'StringValue' => 'Hello, World!',
+            ],
+            'expectedSizeInBytes' => 19,
+        ];
+
+        yield 'integer attribute' => [
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleInteger',
+                '123',
+                SqsMessageAttributeDataType::NUMBER,
+            ),
+            'expectedSqsMessageAttributeValue' => 123,
+            'expectedArray' => [
+                'DataType' => 'Number',
+                'StringValue' => '123',
+            ],
+            'expectedSizeInBytes' => 9,
+        ];
+
+        yield 'float attribute' => [
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleFloat',
+                '123.45',
+                SqsMessageAttributeDataType::NUMBER,
+            ),
+            'expectedSqsMessageAttributeValue' => 123.45,
+            'expectedArray' => [
+                'DataType' => 'Number',
+                'StringValue' => '123.45',
+            ],
+            'expectedSizeInBytes' => 12,
+        ];
+
+        yield 'binary attribute' => [
+            'sqsMessageAttribute' => new SqsMessageAttribute(
+                'exampleBinary',
+                'abc',
+                SqsMessageAttributeDataType::BINARY,
+            ),
+            'expectedSqsMessageAttributeValue' => 'abc',
+            'expectedArray' => [
+                'DataType' => 'Binary',
+                'BinaryValue' => 'abc',
+            ],
+            'expectedSizeInBytes' => 9,
+        ];
+    }
+}

--- a/tests/Queue/AWSSQS/SqsMessageTest.php
+++ b/tests/Queue/AWSSQS/SqsMessageTest.php
@@ -3,6 +3,10 @@
 namespace Tests\BE\QueueManagement\Queue\AWSSQS;
 
 use BE\QueueManagement\Queue\AWSSQS\SqsMessage;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeDataType;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageAttributeFields;
+use BE\QueueManagement\Queue\AWSSQS\SqsMessageFields;
+use Iterator;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -21,6 +25,70 @@ class SqsMessageTest extends TestCase
     public function testIsTooBig(bool $expectedIsTooBig, string $messageBody, array $messageAttributes): void
     {
         Assert::assertSame($expectedIsTooBig, SqsMessage::isTooBig($messageBody, $messageAttributes));
+    }
+
+
+    #[DataProvider('getMessageAttributeDataProvider')]
+    public function testGetMessageAttribute(
+        string $messageAttributeName,
+        ?string $messageAttributeValue,
+        SqsMessageAttributeDataType $messageAttributeDataType,
+        string|int|float|null $expectedResult
+    ): void {
+        $message = [
+            SqsMessageFields::MESSAGE_ATTRIBUTES => [
+                $messageAttributeName => [
+                    $messageAttributeDataType === SqsMessageAttributeDataType::BINARY ?
+                        SqsMessageAttributeFields::BINARY_VALUE->value : SqsMessageAttributeFields::STRING_VALUE->value => $messageAttributeValue,
+                ],
+            ],
+        ];
+
+        $sqsMessage = new SqsMessage($message, 'https://sqs.eu-central-1.amazonaws.com/1234567891/SomeQueue');
+
+        $result = $sqsMessage->getMessageAttribute($messageAttributeName, $messageAttributeDataType);
+
+        Assert::assertSame($expectedResult, $result);
+    }
+
+
+    /**
+     * @return Iterator<string,array{
+     *     messageAttributeName: string,
+     *     messageAttributeValue: ?string,
+     *     messageAttributeDataType: SqsMessageAttributeDataType,
+     *     expectedResult: string|int|float|null,
+     * }>
+     */
+    public static function getMessageAttributeDataProvider(): Iterator
+    {
+        yield 'string attribute' => [
+            'messageAttributeName' => 'exampleString',
+            'messageAttributeValue' => 'Hello, World!',
+            'messageAttributeDataType' => SqsMessageAttributeDataType::STRING,
+            'expectedResult' => 'Hello, World!',
+        ];
+
+        yield 'integer attribute' => [
+            'messageAttributeName' => 'exampleNumberInt',
+            'messageAttributeValue' => '123',
+            'messageAttributeDataType' => SqsMessageAttributeDataType::NUMBER,
+            'expectedResult' => 123,
+        ];
+
+        yield 'float attribute' => [
+            'messageAttributeName' => 'exampleNumberFloat',
+            'messageAttributeValue' => '123.45',
+            'messageAttributeDataType' => SqsMessageAttributeDataType::NUMBER,
+            'expectedResult' => 123.45,
+        ];
+
+        yield 'attribute not set' => [
+            'messageAttributeName' => 'notSet',
+            'messageAttributeValue' => null,
+            'messageAttributeDataType' => SqsMessageAttributeDataType::STRING,
+            'expectedResult' => null,
+        ];
     }
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/28abe910-1ae4-43fb-9927-3033e5c7feec)

- This PR adds `JobInterface::getMessageAttribute` and `JobInterface::setMessageAttribute` which allow for easier working with SQS message attributes and implements them on the `SimpleJob` class.
- Additionally, it adds a convenience method `SqsMessage::getMessageAttribute`
- It also splits the `MessageSentEvent` into `BeforeMessageSentEvent` and `AfterMessageSentEvent`
  - Introduction of `BeforeMessageSentEvent` allows consuming application to intercept the SQS message attributes before the message is sent, and add some metadata of its own (ie data required for observability purposes - like connecting execution graphs between http request and a job it spawns into one)
