### PR TITLE
DE-117618: Keep SqsConsumer member variables protected

### DIFF
--- a/src/Queue/AWSSQS/SqsConsumer.php
+++ b/src/Queue/AWSSQS/SqsConsumer.php
@@ -38,9 +38,9 @@ class SqsConsumer implements SqsConsumerInterface
 
     protected MessageDeduplication $messageDeduplication;
 
-    private DateTimeImmutableFactory $dateTimeImmutableFactory;
+    protected DateTimeImmutableFactory $dateTimeImmutableFactory;
 
-    private QueueManagerInterface $queueManager;
+    protected QueueManagerInterface $queueManager;
 
 
     public function __construct(


### PR DESCRIPTION
This will allow children extending QueueManagement\SqsConsumer to access QueueManager. With that, the children can gracefully terminate the worker if needed.

(Example case is that EntityManager present in container gets closed. As there are no ways to reopen it and many services hold reference to such closed EntityManager, only possibility is to shut down the worker)